### PR TITLE
internal/encoding/csv: do not overwrite values if no NaN

### DIFF
--- a/internal/encoding/csv/writer.go
+++ b/internal/encoding/csv/writer.go
@@ -22,6 +22,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"time"
 
@@ -62,6 +63,7 @@ func (w *Writer) Write(ts browser.TimeSeries) error {
 	if len(ts) == 0 {
 		return browser.ErrDataNotFound
 	}
+
 	// Sort timeseries by station.
 	sort.Slice(ts, func(i, j int) bool { return ts[i].Station.Name < ts[j].Station.Name })
 
@@ -132,7 +134,10 @@ func (w *Writer) Write(ts browser.TimeSeries) error {
 					if !ok {
 						break
 					}
-					w.rows[j][column] = fmt.Sprint(p.Value)
+
+					if !math.IsNaN(p.Value) {
+						w.rows[j][column] = fmt.Sprint(p.Value)
+					}
 					break
 				}
 			}

--- a/internal/encoding/csv/writer_test.go
+++ b/internal/encoding/csv/writer_test.go
@@ -5,6 +5,7 @@
 package csv
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -363,6 +364,55 @@ func TestWrite(t *testing.T) {
 2020-01-01 00:30:00,s2,me_s2,50,3,2,NaN,NaN,10
 2020-01-01 00:45:00,s2,me_s2,50,3,2,NaN,NaN,22
 2020-01-01 01:00:00,s2,me_s2,50,3,2,NaN,NaN,66
+`,
+		},
+		"gl_issue_125": {
+			browser.TimeSeries{
+				&browser.Measurement{
+					Label: "a_avg",
+					Station: &browser.Station{
+						Name:      "s1",
+						Landuse:   "me_s1",
+						Elevation: 1000,
+						Latitude:  3.14159,
+						Longitude: 2.71828,
+					},
+					Unit: "c",
+					Points: []*browser.Point{
+						testPoint("2020-01-01T00:15:00+01:00", 1),
+						testPoint("2020-01-01T00:30:00+01:00", 2),
+						testPoint("2020-01-01T00:45:00+01:00", 3),
+						testPoint("2020-01-01T01:00:00+01:00", 4),
+					},
+				},
+				&browser.Measurement{
+					Label: "a_avg",
+					Unit:  "c/15",
+					Station: &browser.Station{
+						Name:      "s1",
+						Landuse:   "me_s1",
+						Elevation: 1000,
+						Latitude:  3.14159,
+						Longitude: 2.71828,
+					},
+					Points: []*browser.Point{
+						testPoint("2020-01-01T00:15:00+01:00", math.NaN()),
+						testPoint("2020-01-01T00:30:00+01:00", math.NaN()),
+						testPoint("2020-01-01T00:45:00+01:00", math.NaN()),
+						testPoint("2020-01-01T01:00:00+01:00", math.NaN()),
+						testPoint("2020-01-01T01:15:00+01:00", 5),
+						testPoint("2020-01-01T01:30:00+01:00", 6),
+					},
+				},
+			},
+			`time,station,landuse,elevation,latitude,longitude,a_avg
+,,,,,,c
+2020-01-01 00:15:00,s1,me_s1,1000,3.14159,2.71828,1
+2020-01-01 00:30:00,s1,me_s1,1000,3.14159,2.71828,2
+2020-01-01 00:45:00,s1,me_s1,1000,3.14159,2.71828,3
+2020-01-01 01:00:00,s1,me_s1,1000,3.14159,2.71828,4
+2020-01-01 01:15:00,s1,me_s1,1000,3.14159,2.71828,5
+2020-01-01 01:30:00,s1,me_s1,1000,3.14159,2.71828,6
 `,
 		},
 	}


### PR DESCRIPTION
In the case a parameter changes its unit two measurements will of the same parameter will be presented in the given browser.Timeseries. When processing the later overwrites the previous values with NaN. This is not desired.

fixes https://gitlab.inf.unibz.it/lter/browser/-/issues/125