### PR TITLE
internal/http: add development mode for http handler

### DIFF
--- a/cmd/browser/main.go
+++ b/cmd/browser/main.go
@@ -64,6 +64,7 @@ func main() {
 		googleClientID    = fs.String("google.clientid", "", "Google OAuth2 client ID.")
 		googleSecret      = fs.String("google.secret", "", "Google OAuth2 secret.")
 		googleRedirect    = fs.String("google.redirect", "", "Google OAuth2 redirect URL.")
+		devMode           = fs.Bool("dev", false, "Run in development mode.")
 		_                 = fs.String("config", "", "Config file (optional)")
 	)
 
@@ -116,6 +117,7 @@ func main() {
 		http.WithDatabase(db),
 		http.WithStationService(stationService),
 		http.WithAnalyticsCode(*analyticsCode),
+		http.WithDevMode(*devMode),
 	)
 
 	// Initialize authentication handler.

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -26,6 +26,8 @@ type Handler struct {
 	// analytics is a Google Analytics code.
 	analytics string
 
+	devMode bool
+
 	db             browser.Database
 	stationService browser.StationService
 }
@@ -64,7 +66,11 @@ func NewHandler(options ...Option) *Handler {
 	h.mux.HandleFunc("/debug/version", h.handleVersion)
 	h.mux.HandleFunc("/debug/commit", h.handleCommit)
 
-	h.mux.Handle("/assets/", http.FileServer(http.FS(publicFS)))
+	fs := http.FS(publicFS)
+	if h.devMode {
+		fs = http.Dir("./internal/http/")
+	}
+	h.mux.Handle("/assets/", http.FileServer(fs))
 
 	return h
 }
@@ -92,6 +98,12 @@ func WithStationService(s browser.StationService) Option {
 func WithAnalyticsCode(analytics string) Option {
 	return func(h *Handler) {
 		h.analytics = analytics
+	}
+}
+
+func WithDevMode(mode bool) Option {
+	return func(h *Handler) {
+		h.devMode = mode
 	}
 }
 


### PR DESCRIPTION
During development it load assets directly from the local filesystem and
not use the embedded ones.